### PR TITLE
Trim trailing newline character from Vault token

### DIFF
--- a/pkg/client/vault.go
+++ b/pkg/client/vault.go
@@ -46,7 +46,9 @@ func getVaultClient() (*vault.Client, error) {
 			return nil, fmt.Errorf("Vault token is not defined (VAULT_TOKEN or ~/.vault-token)")
 		}
 
-		token = string(f)
+		// The vault client does not handle a trailing newline, so we ensure it
+		// has been removed
+		token = strings.TrimSuffix(string(f), "\n")
 	}
 
 	c.SetToken(token)


### PR DESCRIPTION
We discovered that an error is generated by the Vault client if a token is used that includes a trailing newline character.

```
FATA[2022-11-14T17:14:56+01:00] configured Vault token contains non-printable characters and cannot be used
```

One of my teammates is unable to use the OIDC auth method from inside of a virtual machine and was pasting his token into `~/.vault-token` manually using `vim`. The default behavior of `vim` is to add a trailing newline to a file if none exists when saving the file, which caused him to receive the aforementioned error. He found that someone had [submitted this type of fix to the Vault client](https://github.com/hashicorp/vault/pull/7624), but it was rejected:

> The rationale is Vault should not modify the users token value that it was given, especially in attempt to make the token valid. At this time we believe it's rational to expect anything that supplies the token to ensure it's clean of any leading or trailing characters that would otherwise make the value not match the token exactly

We managed to work around the issue by using `echo -n 'TOKEN' > ~/.vault-token`, but one must go out of their way to ensure the token does not get saved to a history file. There are likely to be other tools we encounter that present the same issue, but since we use `vac` far more than any other tool to interact with Vault, having it trim a trailing new line would be much appreciated.