### PR TITLE
fix: Add file locking around accessing the state file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mvisonneau/vac
 go 1.22
 
 require (
+	github.com/gofrs/flock v0.12.0
 	github.com/hashicorp/go-secure-stdlib/mlock v0.1.3
 	github.com/hashicorp/vault/api v1.14.0
 	github.com/ktr0731/go-fuzzyfinder v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -285,6 +285,8 @@ github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.0.2/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/flock v0.12.0 h1:xHW8t8GPAiGtqz7KxiSqfOEXwpOaqhpYZrTE2MQBgXY=
+github.com/gofrs/flock v0.12.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -528,8 +530,9 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -708,6 +711,7 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
 github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=

--- a/internal/cmd/get.go
+++ b/internal/cmd/get.go
@@ -53,6 +53,14 @@ func Get(ctx *cli.Context) (int, error) {
 		return 1, err
 	}
 
+	locked, unlock, err := fileLock(cfg.LockPath)
+	if err != nil {
+		return 1, err
+	}
+	if locked {
+		defer unlock()
+	}
+
 	s, err := state.Read(cfg.StatePath)
 	if err != nil {
 		return 1, err

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -25,6 +25,14 @@ func Status(ctx *cli.Context) (int, error) {
 		return 1, err
 	}
 
+	locked, unlock, err := fileLock(cfg.LockPath)
+	if err != nil {
+		return 1, err
+	}
+	if locked {
+		defer unlock()
+	}
+
 	s, err := state.Read(cfg.StatePath)
 	if err != nil {
 		return 1, err

--- a/internal/cmd/switch.go
+++ b/internal/cmd/switch.go
@@ -21,6 +21,14 @@ func Switch(ctx *cli.Context) (int, error) {
 		return 1, err
 	}
 
+	locked, unlock, err := fileLock(cfg.LockPath)
+	if err != nil {
+		return 1, err
+	}
+	if locked {
+		defer unlock()
+	}
+
 	s, err := state.Read(cfg.StatePath)
 	if err != nil {
 		return 1, err

--- a/internal/cmd/utils_test.go
+++ b/internal/cmd/utils_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -34,4 +37,24 @@ func TestExit(t *testing.T) {
 	err := exit(20, fmt.Errorf("test"))
 	assert.Equal(t, "", err.Error())
 	assert.Equal(t, 20, err.ExitCode())
+}
+
+const charSet = "abcdefghijklmnopqrstuvwxyz"
+
+func randString(strlen int) string {
+	result := make([]byte, strlen)
+	for i := 0; i < strlen; i++ {
+		result[i] = charSet[rand.Intn(len(charSet))] //nolint:gosec
+	}
+	return string(result)
+}
+
+func TestFileLock(t *testing.T) {
+	fp := filepath.Join(os.TempDir(), randString(8))
+	ok, unlock, err := fileLock(fp)
+	assert.Nil(t, err)
+	assert.True(t, ok)
+	assert.FileExists(t, fp)
+	defer os.Remove(fp)
+	defer unlock()
 }


### PR DESCRIPTION
I found that `vac` has a race condition if you run multiple instances in parallel; each instance reads in the state file, adds the refreshed credentials to the state, then writes out the updated state file. The last instance to do that will revert any other updated credentials and only store the ones it updated.

I have around 28 AWS accounts and was using Steampipe to query them, which if I query across all accounts, launches multiple queries in parallel which demonstrates this problem. I was confused why `vac status` only showed some credentials as being refreshed.

This PR adds some file locking around the state file so only one `vac` process can read (and write) the state file at any one time. With this change applied, `vac status` now shows all account credentials refreshing correctly. The lock file used is the same path as the state file itself, with a `.lock` extension.